### PR TITLE
readme: use marky-markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,14 @@
 # Timing safe string compare using double HMAC
-[![Node.js Version][node-version-image]][node-version-url]
-[![npm][npm-image]][npm-url]
-[![NPM Downloads][downloads-image]][downloads-url]
-[![Build Status][travis-image]][travis-url]
-[![Build Status][appveyor-image]][appveyor-url]
-[![Dependency Status][david-image]][david-url]
-[![github-license][github-license-image]][license-url]
-[travis-image]: https://img.shields.io/travis/suryagh/tsscmp/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/suryagh/tsscmp
-[appveyor-image]: https://img.shields.io/appveyor/ci/suryagh/tsscmp/master.svg?style=flat-square&label=windows
-[appveyor-url]: https://ci.appveyor.com/project/suryagh/tsscmp
-[npm-image]: https://img.shields.io/npm/v/tsscmp.svg?style=flat-square
-[npm-url]: https://npmjs.org/package/tsscmp
-[node-version-image]: https://img.shields.io/node/v/tsscmp.svg?style=flat-square
-[node-version-url]: https://nodejs.org/en/download
-[downloads-image]: https://img.shields.io/npm/dm/tsscmp.svg?style=flat-square
-[downloads-url]: https://npmjs.org/package/tsscmp
-[david-image]: http://img.shields.io/david/suryagh/tsscmp.svg?style=flat-square
-[david-url]: https://david-dm.org/suryagh/tsscmp
-[npm-license-image]: http://img.shields.io/npm/l/tsscmp.svg?style=flat-square
-[github-license-image]: https://img.shields.io/github/license/suryagh/tsscmp.svg?style=flat-square
-[license-url]: LICENSE
+
+[![Node.js Version](https://img.shields.io/node/v/tsscmp.svg?style=flat-square)](https://nodejs.org/en/download)
+[![npm](https://img.shields.io/npm/v/tsscmp.svg?style=flat-square)](https://npmjs.org/package/tsscmp)
+[![NPM Downloads](https://img.shields.io/npm/dm/tsscmp.svg?style=flat-square)](https://npmjs.org/package/tsscmp)
+[![Build Status](https://img.shields.io/travis/suryagh/tsscmp/master.svg?style=flat-square)](https://travis-ci.org/suryagh/tsscmp)
+[![Build Status](https://img.shields.io/appveyor/ci/suryagh/tsscmp/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/suryagh/tsscmp)
+[![Dependency Status](http://img.shields.io/david/suryagh/tsscmp.svg?style=flat-square)](https://david-dm.org/suryagh/tsscmp)
+[![npm-license](http://img.shields.io/npm/l/tsscmp.svg?style=flat-square)](LICENSE)
+
+
 Prevents [timing attacks](http://codahale.com/a-lesson-in-timing-attacks/) using Brad Hill's
 [Double HMAC pattern](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2011/february/double-hmac-verification/)
 to perform secure string comparison. Double HMAC avoids the timing atacks by blinding the
@@ -51,11 +39,10 @@ if (timingSafeCompare(sessionToken, givenToken)) {
   console.log('bad token');
 }
 ```
-## Credits to
-[@jsha](https://github.com/jsha)</br>
-[@bnoordhuis](https://github.com/bnoordhuis)</br>
-[@suryagh](https://github.com/suryagh)
+##License: 
+[MIT](LICENSE)
 
-## License
- [MIT](LICENSE)
+**Credits to:**  [@jsha](https://github.com/jsha) |
+[@bnoordhuis](https://github.com/bnoordhuis) |
+[@suryagh](https://github.com/suryagh) |
  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsscmp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Timing safe string compare using double HMAC",
   "main": "lib/index.js",
   "dependencies": {},


### PR DESCRIPTION
To fix the readme on npmjs.org, will have to use `marky-markdown` parser syntax. This is different from the parser that github uses. For e.g., `marky-markdown` does not like:

```
[![Node.js Version][node-version-image]][node-version-url]
```

And will need to be replaced as:

```
[![Node.js Version](https://img.shields.io/node/v/tsscmp.svg?style=flat-square)](https://nodejs.org/en/download)
```
