### PR TITLE
remove publishCOnfig, which hardcodes registry.npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "hmac"
   ],
   "author": "suryagh",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org"
-  },
   "engines": {
     "node": ">=0.6.x"
   },


### PR DESCRIPTION
fixes #12 