### PR TITLE
chore: add `.travis.yml` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test
+.travis.yml
 appveyor.yml


### PR DESCRIPTION
This doesn't need to be included in the published package.