### PR TITLE
use randomBytes instead of pseudoRandomBytes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,10 @@
 // https://github.com/nodejs/node/issues/3043
 // https://github.com/nodejs/node/pull/3073
 
+var major = parseInt(process.version.substr(1).split('.')[0], 10);
 var crypto = require('crypto');
+
+var randomBytes = major >= 10 ? crypto.randomBytes : crypto.pseudoRandomBytes;
 
 function bufferEqual(a, b) {
   if (a.length !== b.length) {
@@ -28,7 +31,7 @@ function bufferEqual(a, b) {
 function timeSafeCompare(a, b) {
   var sa = String(a);
   var sb = String(b);
-  var key = crypto.pseudoRandomBytes(32);
+  var key = randomBytes(32);
   var ah = crypto.createHmac('sha256', key).update(sa).digest();
   var bh = crypto.createHmac('sha256', key).update(sb).digest();
 


### PR DESCRIPTION
Used `crypto.pseudoRandomBytes` is on the [deprecation list](https://nodejs.org/docs/v16.8.0/api/deprecations.html#DEP0115) and might be removed in the future, this PR updates to use `crypto.randomBytes` instead while sticking to use of pseudoRandomBytes on node versions before it was aliased to use `crypto.randomBytes` internally.

A non-breaking change for all node.js versions this module targets.